### PR TITLE
Recognized CSV inputs in semantic-uplifts transformer

### DIFF
--- a/ogc/bblocks/transformers/semantic-uplift.py
+++ b/ogc/bblocks/transformers/semantic-uplift.py
@@ -12,6 +12,7 @@ transform_type = 'semantic-uplift'
 
 default_inputs = [
     'application/json',
+    'text/csv'
 ]
 
 default_outputs = [
@@ -26,6 +27,11 @@ class SemanticUpliftTransformer(Transformer):
 
     def do_transform(self, metadata: TransformMetadata) -> AnyStr | None:
         uplift_def = load_yaml(content=metadata.transform_content)
+        if metadata.source_mime_type == 'text/csv':
+            raise NotImplementedError(
+                "CSV input detected for semantic-uplift. "
+                "CSV->RDF uplift is not implemented yet (hook added for #59)."
+            )
         uplifted = json.dumps(ingest_json.uplift_json(json.loads(metadata.input_data), uplift_def))
         data_graph = Graph().parse(data=uplifted, format='json-ld')
         return data_graph.serialize(format=metadata.target_mime_type)


### PR DESCRIPTION
Related to #59

This PR adds `text/csv` as a recognized input type for the `semantic-uplift`
transformer and explicitly detects CSV inputs with a clear error.

This establishes a clean integration hook for future CSV->RDF semantic
uplift using OGC NA tools, without changing existing JSON behavior.